### PR TITLE
Fix template iterations

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,7 +19,7 @@ class netrc {
 
 define netrc::foruser($root_home_directory="/home",$user, $machine_user_password_triples) {
 	$filename = ".netrc"
-	$prefixes = ['machine ','	login ','	password ']
+	$prefixes = ['machine','	login','	password']
 	
 	file { "$root_home_directory/$user/$filename":
 		ensure => present,

--- a/templates/netrc.erb
+++ b/templates/netrc.erb
@@ -1,5 +1,5 @@
 <% machine_user_password_triples.each do |triple|
   triple.each_with_index do |triple_part,index|
-    -%><%= prefixes[index] %><%= triple_part %>
+    -%><%= prefixes[index] %> <%= triple_part %>
   <% end -%>
 <% end -%>

--- a/templates/netrc.erb
+++ b/templates/netrc.erb
@@ -1,3 +1,5 @@
-<% machine_user_password_triples.each_with_index do |triple_part,index|
-        i=index%3 -%><%= prefixes[i] %><%= triple_part %>
+<% machine_user_password_triples.each do |triple|
+  triple.each_with_index do |triple_part,index|
+    -%><%= prefixes[index] %><%= triple_part %>
+  <% end -%>
 <% end -%>


### PR DESCRIPTION
There's a problem in your template iteration: Your `each_with_index` gives the index of the triple, not of the triple part. Actually, you never iterate over triple parts so you never get the prefix index.

The result was like `myhostumysermypassword` instead of
```
machine myhost
        login myuser
        password mypassword
````

Incidentally, I've removed some redundant spaces in the prefixes.

There are secundary things I'd like to change, like looking for the user home in /etc/passwd instead of generating the path but I'll post them later if the module is still maintained.